### PR TITLE
Return value of p.communicate() is bytes, not string

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ if os.path.isfile(readme):
     out, err = p.communicate()
     if p.returncode != 0:
         raise Exception("pandoc conversion failed: " + err)
-    long_description = out
+    long_description = out.decode("utf-8")
 else:
     long_description = ""
 


### PR DESCRIPTION
With `pip3 install`, the setup routines will fail with
```
TypeError: a bytes-like object is required, not str
```
unless we properly convert `long_description` to string.