### PR TITLE
avoid sucking down a cpu when input pipe closes

### DIFF
--- a/jsonrpyc/__init__.py
+++ b/jsonrpyc/__init__.py
@@ -713,9 +713,12 @@ class Watchdog(threading.Thread):
             # handle new lines if any
             if lines:
                 for b_line in lines:
-                    line = b_line.decode("utf-8").strip()
-                    if line:
-                        self.rpc._handle(line)
+                    if not b_line:
+                        self.stop()
+                    else:
+                        line = b_line.decode("utf-8").strip()
+                        if line:
+                            self.rpc._handle(line)
             else:
                 self._stop.wait(self.interval)
 


### PR DESCRIPTION
```
python - <<EOF
from time import sleep
import jsonrpyc; from subprocess import Popen, PIPE
p=Popen(["sleep", "120"], stdin=PIPE, stdout=PIPE)
rpc = jsonrpyc.RPC(stdin=p.stdout)
p.kill()
while rpc.watchdog.is_alive():
  sleep(1)
EOF
```
Now look at the processes on your machine.  At least on my Linux system, I see the python suck down a core.